### PR TITLE
should say "sample" not "internal" for customers

### DIFF
--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -32,7 +32,7 @@ const Splash: React.FC = () => {
     <div className={classes.root}>
       <Chip
         className={classes.chip}
-        label="Bandwidth Web Conferencing is for internal use only. Please use Chrome browser for best results."
+        label="Bandwidth Web Conferencing is for sample use only. Please use Chrome browser for best results."
       />
     </div>
   );


### PR DESCRIPTION
Small but important change noticed for the frontend splash page, message at the bottom of the page.  "internal" is wrong.

![image](https://user-images.githubusercontent.com/55767198/84304013-e60d6a80-ab25-11ea-9202-edded64fe54b.png)
